### PR TITLE
flounder: OTG fixes

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -238,6 +238,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     ro.enable_boot_charger_mode=1
 
+# Enable USB OTG (CAF commit to Settings)
+ADDITIONAL_BUILD_PROPERTIES += \
+    persist.sys.isUsbOtgEnabled=true
+
 # add verity dependencies
 $(call inherit-product, build/target/product/verity.mk)
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/sdhci-tegra.3/by-name/APP


### PR DESCRIPTION
add persist.sys.isUsbOtgEnabled=true build property

Change-Id: Id1a54461a428cd033c927e15c2d02cbf3e411f03