### PR TITLE
flounder: use gcc 4.8 vs 4.9

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -16,7 +16,7 @@ $(call inherit-product, device/htc/flounder/aosp_flounder.mk)
 $(call inherit-product-if-exists, vendor/htc/flounder/device-vendor.mk)
 
 # Inline kernel building
-KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/aarch64/aarch64-linux-android-4.9/bin
+KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/aarch64/aarch64-linux-android-4.8/bin
 KERNEL_TOOLCHAIN_PREFIX := aarch64-linux-android-
 TARGET_KERNEL_SOURCE := kernel/htc/flounder
 TARGET_KERNEL_CONFIG := flounder_defconfig


### PR DESCRIPTION
Change-Id: Ib5b09f79b53025cdcd59b70289b3de722edb8802
Signed-off-by: Simon Sickle <simon@simonsickle.com>