### PR TITLE
flounder: dont need to define FFMPEG anymore

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -27,10 +27,6 @@ BOARD_KERNEL_CMDLINE := androidboot.selinux=enforcing
 PRODUCT_PACKAGES += \
     com.android.nfc_extras
 
-# Copy Extra Files
-PRODUCT_COPY_FILES += \
-    frameworks/av/media/libstagefright/data/media_codecs_ffmpeg.xml:system/etc/media_codecs_ffmpeg.xml
-
 # CM Overlays
 DEVICE_PACKAGE_OVERLAYS += device/htc/flounder/overlay-cm
 


### PR DESCRIPTION
Change-Id: I2ad3845991715252c32d482e5e82bc3cd59e5bbb
Signed-off-by: Simon Sickle <simon@simonsickle.com>