### PR TITLE
Add support for the notification light

### DIFF
--- a/init.flounder.rc
+++ b/init.flounder.rc
@@ -111,6 +111,10 @@ on boot
     chown system system /sys/devices/system/cpu/cpufreq/interactive/io_is_busy
     chmod 0660 /sys/devices/system/cpu/cpufreq/interactive/io_is_busy
 
+    # white notification LED
+    chown system system /sys/class/htc_sensorhub/sensor_hub/led_en
+    chmod 664           /sys/class/htc_sensorhub/sensor_hub/led_en
+
     # Enable CC4
     write /sys/devices/system/cpu/cpu0/cpuidle/state1/disabled 0
     write /sys/devices/system/cpu/cpu1/cpuidle/state1/disabled 0

--- a/overlay-cm/frameworks/base/core/res/res/values/config.xml
+++ b/overlay-cm/frameworks/base/core/res/res/values/config.xml
@@ -47,4 +47,23 @@
          For example, a device with Home, Back and Menu keys would set this
          config to 7. -->
     <integer name="config_deviceHardwareWakeKeys">64</integer>
+
+    <!-- Is the notification LED intrusive?
+         Used to decide if there should be a disable option -->
+    <bool name="config_intrusiveNotificationLed">true</bool>
+
+    <!-- Does the notification LED support multiple colors?
+         Used to decide if the user can change the colors -->
+    <bool name="config_multiColorNotificationLed">false</bool>
+
+    <!-- Default color for notification LED is white. -->
+    <color name="config_defaultNotificationColor">#ffffffff</color>
+
+    <!-- Is the battery LED intrusive?
+         Used to decide if there should be a disable option -->
+    <bool name="config_intrusiveBatteryLed">false</bool>
+
+    <!-- Does the battery LED support multiple colors?
+         Used to decide if the user can change the colors -->
+    <bool name="config_multiColorBatteryLed">false</bool>
 </resources>


### PR DESCRIPTION
The LED trigger is boolean only, so there's no reasonable way of adding
battery light support as well.

Change-Id: Iaf1f62feefb2e2c3c2a51d71f996fa6a4e30272c