### PR TITLE
flounder: Create /system/etc/firmware at build time

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,4 +28,11 @@ LOCAL_PATH := $(call my-dir)
 # their rules should be written here.
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
+
+include $(CLEAR_VARS)
+
+# This fixes the problem of nonexistent /system/etc/firmware/ which is causing
+# problems to boot at fw's load time
+$(shell mkdir -p $(TARGET_OUT)/etc/firmware)
+
 endif


### PR DESCRIPTION
This fixes the problem brought by:
9008630f - init: Add support for gzipped firmware files on
CyanogenMod/android_system_core

Change-Id: Idb34c47009f5de24161e847e628a3d4eb50512a7