### PR TITLE
Revert "flounder: dont import svelte config on wifi device"

### DIFF
--- a/init.flounder.rc
+++ b/init.flounder.rc
@@ -1,5 +1,5 @@
 import init.flounder.usb.rc
-#import init.flounder_svelte.rc
+import init.flounder_svelte.rc
 
 on init
     # Load persistent dm-verity state


### PR DESCRIPTION
This revert brings again the smooth gpu clock needed for thermal throttle avoidance.

This reverts commit 5229b3aff7ae42b443a750600dbc54bd40287487.

Change-Id: I4f46fc661684fb03f91d1660c3628e709dbc5419
(cherry picked from commit 98f60908f9d4d6d4848ef1651d21f98c5cc7b675)