### PR TITLE
Update fingerprint to MMB29K and override build_id for verity

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -35,8 +35,9 @@ DEVICE_PACKAGE_OVERLAYS += device/htc/flounder/overlay-cm
 
 PRODUCT_BUILD_PROP_OVERRIDES += \
     PRODUCT_NAME=flounder \
-    BUILD_FINGERPRINT=google/volantis/flounder:6.0/MRA58N/2289998:user/release-keys \
-    PRIVATE_BUILD_DESC="volantis-user 6.0 MRA58N 2289998 release-keys"
+    BUILD_FINGERPRINT=google/volantis/flounder:6.0.1/MMB29K/2419427:user/release-keys \
+    PRIVATE_BUILD_DESC="volantis-user 6.0.1 MMB29K 2419427 release-keys" \
+    BUILD_ID=MMB29K
 
 ## Device identifier. This must come after all inclusions
 PRODUCT_NAME := cm_flounder


### PR DESCRIPTION
Change-Id: Ie5e58ba89a39358bb0a0b8362be9fb2f6408306d