### PR TITLE
flounder: hack to workaround wifi-events.rc causing panic

### DIFF
--- a/init.flounder.rc
+++ b/init.flounder.rc
@@ -57,6 +57,9 @@ on post-fs-data
     mkdir /data/efs 0771 system system
     mkdir /data/qcks/mdm 0770 system system
 
+    # hack to workaround wifitracing causing panic
+    setprop sys.wifitracing.started 1
+
     setprop vold.post_fs_data_done 1
 
 on boot


### PR DESCRIPTION
* writing to /sys/kernel/debug/tracing/instances currently causes a
kernel panic
* hack to prevent wifi-events.rc from writing to this until a kernel fix
is implemented

Change-Id: I55f2e0a127feb63404745ce6c8e42525a1848642