### PR TITLE
flounder: Remove wificond from device makefiles

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -19,7 +19,6 @@ PRODUCT_PACKAGES := \
     android.hardware.wifi@1.0-service \
     libwpa_client \
     hostapd \
-    wificond \
     wpa_supplicant \
     wpa_supplicant.conf
 


### PR DESCRIPTION
 * This package is being built globally

Change-Id: I70aaf469acc29ded3cf5bb24ab112a76b36a7835