### PR TITLE
flounder: Set vendor security patch level

### DIFF
--- a/lineage.mk
+++ b/lineage.mk
@@ -31,6 +31,10 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
 # Set BUILD_FINGERPRINT variable to be picked up by both system and vendor build.prop
 BUILD_FINGERPRINT := google/volantis/flounder:7.1.1/N9F27M/4333998:user/release-keys
 
+# Vendor security patch level
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.lineage.build.vendor_security_patch=2017-10-05
+
 ## Device identifier. This must come after all inclusions
 PRODUCT_NAME := lineage_flounder
 PRODUCT_BRAND := google


### PR DESCRIPTION
 * As per 7.1.1 (N9F27M, Oct 2017) factory image

Change-Id: I1308c1b5aa0a1e1c43cd7609d803e011afd98ec0